### PR TITLE
Feat/mlflow fm

### DIFF
--- a/airflow/dags/mlops_fm_data_dag.py
+++ b/airflow/dags/mlops_fm_data_dag.py
@@ -1,0 +1,48 @@
+import os
+from datetime import timedelta
+from airflow import DAG
+from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+from airflow.operators.dummy import DummyOperator
+from airflow.utils.dates import days_ago    
+from common.env_loader import load_env
+from tasks.create_fm_dataset import generate_fm_input
+
+load_env()
+
+SPARK_PATH = os.getenv("SPARK_PATH")
+JDBC_JAR_PATH = os.getenv("JDBC_JAR_PATH")
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+with DAG(
+    'mlops_fm_data_dag',
+    default_args=default_args,
+    description='MLOps for food menu comparison',
+    schedule_interval='0 21 * * *',
+    start_date=days_ago(1),
+    catchup=False,
+    tags=['mlops', 'food_menu_comparison'],
+) as dag:
+    start = DummyOperator(task_id="start")
+
+    food_menu_comparison_job = SparkSubmitOperator(
+        task_id='food_menu_comparison',
+        application=f"{SPARK_PATH}/data-mart/create_dm_mlops_data.py",
+        conn_id="spark_default",
+        conf={"spark.executor.memory": "2g"},
+        jars=JDBC_JAR_PATH,
+        application_args=["{{ ds }}"],
+    )
+
+    generate_fm_task = generate_fm_input.override(task_id='generate_fm_input_data')("{{ ds }}")
+
+    end = DummyOperator(task_id="end")
+
+    start >> food_menu_comparison_job >> generate_fm_task >> end

--- a/airflow/dags/mlops_fm_train_dag.py
+++ b/airflow/dags/mlops_fm_train_dag.py
@@ -1,0 +1,98 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+import subprocess
+import mlflow
+
+
+def train_fm_model(ds, **kwargs):
+    data_path = f"/opt/airflow/data/train_{ds}.libfm"
+    model_path = f"/opt/airflow/models/fm_model_{ds}.bin"
+    pred_path = f"/opt/airflow/data/pred_{ds}.txt"
+
+    dim = "1,1,8"
+    iter_ = 50
+    lr = 0.01
+    method = "sgd"
+
+    # MLflow 설정
+    mlflow.set_tracking_uri("http://mlflow:5000")
+    mlflow.set_experiment("fm_recommender")
+
+    with mlflow.start_run(run_name=f"train_{ds}") as run:
+        run_id = run.info.run_id
+
+        mlflow.log_param("dim", dim)
+        mlflow.log_param("iter", iter_)
+        mlflow.log_param("learn_rate", lr)
+        mlflow.log_param("method", method)
+        mlflow.log_param("date", ds)
+
+        # libFM 학습 실행
+        subprocess.run([
+            "libfm",
+            "-task", "c",
+            "-train", data_path,
+            "-out", pred_path,
+            "-model", model_path,
+            "-dim", dim,
+            "-iter", str(iter_),
+            "-method", method,
+            "-learn_rate", str(lr)
+        ], check=True)
+
+        mlflow.log_artifact(data_path, artifact_path="data")
+        mlflow.log_artifact(pred_path, artifact_path="pred")
+        mlflow.log_artifact(model_path, artifact_path="model")
+
+        # run_id XCom으로 전달
+        kwargs['ti'].xcom_push(key='run_id', value=run_id)
+
+
+def evaluate_fm_model(ds, **kwargs):
+    run_id = kwargs['ti'].xcom_pull(key='run_id', task_ids='train_fm')
+    pred_path = f"/opt/airflow/data/pred_{ds}.txt"
+    label_path = f"/opt/airflow/data/true_{ds}.txt"
+
+    import numpy as np
+    from sklearn.metrics import mean_squared_error, precision_score, recall_score
+
+    y_pred = np.loadtxt(pred_path)
+    y_true = np.loadtxt(label_path)
+    y_bin = (y_pred >= 0.5).astype(int)
+
+    rmse = mean_squared_error(y_true, y_pred, squared=False)
+    precision = precision_score(y_true, y_bin, zero_division=0)
+    recall = recall_score(y_true, y_bin, zero_division=0)
+
+    print(f"RMSE: {rmse:.4f}, Precision: {precision:.4f}, Recall: {recall:.4f}")
+
+    mlflow.set_tracking_uri("http://mlflow:5000")
+    mlflow.start_run(run_id=run_id)
+    mlflow.log_metric("rmse", rmse)
+    mlflow.log_metric("precision", precision)
+    mlflow.log_metric("recall", recall)
+    mlflow.end_run()
+
+
+with DAG(
+    dag_id="mlops_fm_train_dag",
+    start_date=datetime(2024, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    tags=["fm", "mlflow"]
+) as dag:
+
+    train = PythonOperator(
+        task_id="train_fm",
+        python_callable=train_fm_model,
+        provide_context=True
+    )
+
+    evaluate = PythonOperator(
+        task_id="evaluate_fm",
+        python_callable=evaluate_fm_model,
+        provide_context=True
+    )
+
+    train >> evaluate

--- a/airflow/dags/monthly_report_dag.py
+++ b/airflow/dags/monthly_report_dag.py
@@ -50,7 +50,7 @@ with DAG(
         application=f"{SPARK_PATH}/data-mart/create_dm_monthly_food_ranking.py",
         conn_id="spark_default",
         conf={"spark.executor.memory": "2g"},
-        application_args=[get_current_month()],
+        application_args=[get_previous_month()],
         jars=JDBC_JAR_PATH,
     )
 
@@ -59,7 +59,7 @@ with DAG(
         application=f"{SPARK_PATH}/data-mart/create_dm_monthly_count.py",
         conn_id="spark_default",
         conf={"spark.executor.memory": "2g"},
-        application_args=[get_current_month()],
+        application_args=[get_previous_month()],
         jars=JDBC_JAR_PATH,
     )
 
@@ -68,7 +68,7 @@ with DAG(
         application=f"{SPARK_PATH}/data-mart/create_dm_monthly_statistic.py",
         conn_id="spark_default",
         conf={"spark.executor.memory": "2g"},
-        application_args=[get_current_month()],
+        application_args=[get_previous_month()],
         jars=JDBC_JAR_PATH,
     )
 
@@ -77,7 +77,7 @@ with DAG(
         application=f"{SPARK_PATH}/data-mart/create_dm_monthly_frequent_evaluator.py",
         conn_id="spark_default",
         conf={"spark.executor.memory": "2g"},
-        application_args=[get_current_month()],
+        application_args=[get_previous_month()],
         jars=JDBC_JAR_PATH,
     )
     

--- a/airflow/dags/tasks/create_fm_dataset.py
+++ b/airflow/dags/tasks/create_fm_dataset.py
@@ -1,0 +1,64 @@
+from airflow.decorators import task
+import pandas as pd
+from sklearn.preprocessing import OneHotEncoder
+import json
+import sys
+import os
+
+# Add the project root to the Python path to import utils
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+from utils.db import get_mysql_connection
+
+@task
+def generate_fm_input(target_date):
+    # 데이터베이스 연결 설정 (pymysql 직접 사용)
+    conn = get_mysql_connection()
+    
+    # 1. 데이터 로딩 (날짜별로 쿼리)
+    query = f"SELECT * FROM ssabab_dm.ml_menu_comparison WHERE date = '{target_date}'"
+    df = pd.read_sql(query, con=conn)
+    
+    # 데이터가 없으면 빈 파일 생성하고 종료
+    if df.empty:
+        print(f"No data found for date: {target_date}")
+        with open(f"/opt/mlops/data/train_{target_date}.libfm", "w") as f:
+            f.write("")  # 빈 파일 생성
+        conn.close()
+        return
+
+    # 2. 사용자 특성 인코딩
+    user_ohe = OneHotEncoder()
+    user_feat = user_ohe.fit_transform(df[['user_id', 'gender', 'region', 'class_num']])
+
+    # 3. 음식 태그 벡터 (JSON → 펼침)
+    def json_to_dict_list(col):
+        return pd.json_normalize([json.loads(x) if x else {} for x in col])
+
+    tags_a = json_to_dict_list(df['tag_vector_a'])
+    tags_b = json_to_dict_list(df['tag_vector_b'])
+
+    # 4. 평점 정보 등 추가
+    df_features = pd.concat([
+        pd.DataFrame(user_feat.toarray()),
+        tags_a.add_prefix("tag_a_"),
+        tags_b.add_prefix("tag_b_"),
+        df[['avg_food_score_a', 'avg_food_score_b']],
+        df['label']
+    ], axis=1)
+
+    # 5. libFM 포맷으로 변환
+    def to_libfm(df):
+        libfm_lines = []
+        for _, row in df.iterrows():
+            label = int(row['label'])
+            features = [f"{i}:{1}" for i in range(len(row)-1) if row.iloc[i] != 0]
+            line = f"{label} " + " ".join(features)
+            libfm_lines.append(line)
+        return libfm_lines
+
+    libfm_data = to_libfm(df_features)
+    with open(f"/opt/mlops/data/train_{target_date}.libfm", "w") as f:
+        f.writelines("\n".join(libfm_data))
+    
+    # 연결 종료
+    conn.close()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ x-airflow-common: &airflow-common
     - ./utils:/opt/airflow/utils
     - ./spark/spark-jobs:/opt/spark-jobs
     - ./spark/jars:/opt/spark-jars
+    - ./mlops:/opt/mlops
     - .env:/opt/.env 
   user: "${AIRFLOW_UID:-1000}:0"
   depends_on:
@@ -260,6 +261,26 @@ services:
   #     - kafka_data:/bitnami/kafka
   #   networks:
   #     - ssabab
+
+  mlflow:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.mlflow
+    container_name: mlflow
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    command: >
+      mlflow server
+      --backend-store-uri mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE_MLFLOW}
+      --default-artifact-root /mlflow/artifacts
+      --host 0.0.0.0
+      --port 5000
+    volumes:
+      - ./mlops/mlflow/artifacts:/mlflow/artifacts
+    networks:
+      - ssabab
 
 volumes:
   postgres-db-volume:

--- a/docker/Dockerfile.mlflow
+++ b/docker/Dockerfile.mlflow
@@ -1,0 +1,3 @@
+FROM ghcr.io/mlflow/mlflow:latest
+
+RUN pip install pymysql

--- a/erd/ssabab_dm.erd.json
+++ b/erd/ssabab_dm.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 2000,
     "height": 2000,
-    "scrollTop": -337.4958,
-    "scrollLeft": -286.0897,
-    "zoomLevel": 0.67,
+    "scrollTop": 0,
+    "scrollLeft": 0,
+    "zoomLevel": 1,
     "show": 431,
     "database": 16,
     "databaseName": "",
@@ -38,7 +38,10 @@
       "SrvkylR2_N90GUNAp0GYs",
       "0aSawkotBtUvi5oqOmmyd",
       "ln56DI9getvYTEpATq3ad",
-      "gvNw89GeHxzNzb2kOG0Tf"
+      "gvNw89GeHxzNzb2kOG0Tf",
+      "Q0xopLdzEA-3f-1nF6xeG",
+      "xaLUTy9c4mxwakZJ9Rlnz",
+      "aiSl3xVOB6NILvVS-vhBV"
     ],
     "relationshipIds": [],
     "indexIds": [],
@@ -55,7 +58,8 @@
           "rdFnc7tUrZH43U_2_A3M2",
           "rLKUNvJIddwMRZXKUAdbS",
           "Lz-8DfQ1WT_gKU9U3--dk",
-          "kwVn6aR_LMjztWpQ5LTsv"
+          "kwVn6aR_LMjztWpQ5LTsv",
+          "pfW0CRc8rAp0-hSr4apnH"
         ],
         "seqColumnIds": [
           "k2_-6gZZwVSbhqeqgklhi",
@@ -63,7 +67,8 @@
           "rdFnc7tUrZH43U_2_A3M2",
           "rLKUNvJIddwMRZXKUAdbS",
           "Lz-8DfQ1WT_gKU9U3--dk",
-          "kwVn6aR_LMjztWpQ5LTsv"
+          "kwVn6aR_LMjztWpQ5LTsv",
+          "pfW0CRc8rAp0-hSr4apnH"
         ],
         "ui": {
           "x": 53.9024,
@@ -74,7 +79,7 @@
           "color": "#3F51B5"
         },
         "meta": {
-          "updateAt": 1750085166119,
+          "updateAt": 1750765015075,
           "createAt": 1746683497255
         }
       },
@@ -307,6 +312,98 @@
         "meta": {
           "updateAt": 1750737507008,
           "createAt": 1750096511236
+        }
+      },
+      "Q0xopLdzEA-3f-1nF6xeG": {
+        "id": "Q0xopLdzEA-3f-1nF6xeG",
+        "name": "dm_monthly_count",
+        "comment": "월간 평가수",
+        "columnIds": [
+          "By9HRYZW5vLYg3lUjNI3V",
+          "rj0G2MNfu-V9dnwL59G-l",
+          "fRw-0ZAbWGpXW6u9dsgs1"
+        ],
+        "seqColumnIds": [
+          "By9HRYZW5vLYg3lUjNI3V",
+          "rj0G2MNfu-V9dnwL59G-l",
+          "fRw-0ZAbWGpXW6u9dsgs1",
+          "GgUw7uzosZgeOLeFAEQ_U"
+        ],
+        "ui": {
+          "x": 53,
+          "y": 269,
+          "zIndex": 315,
+          "widthName": 103,
+          "widthComment": 65,
+          "color": "#3F51B5"
+        },
+        "meta": {
+          "updateAt": 1750765051239,
+          "createAt": 1750765032742
+        }
+      },
+      "xaLUTy9c4mxwakZJ9Rlnz": {
+        "id": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "dm_monthly_statistic",
+        "comment": "월간 통계",
+        "columnIds": [
+          "NZiQOpaBYQyYlsniC4chh",
+          "gUfB9WFnqCsSSgh4v5y1Q",
+          "V8W8Q4iP9QzR3KvOJNpx8",
+          "eH5cBr8UaC30iBHRw2J80",
+          "JueMfHPJF0D246XgCRsTo",
+          "SIZsCEhnVgf1b0pf2pE9x",
+          "jvIhT7CNJB2xhe1prdI97"
+        ],
+        "seqColumnIds": [
+          "NZiQOpaBYQyYlsniC4chh",
+          "gUfB9WFnqCsSSgh4v5y1Q",
+          "V8W8Q4iP9QzR3KvOJNpx8",
+          "eH5cBr8UaC30iBHRw2J80",
+          "JueMfHPJF0D246XgCRsTo",
+          "SIZsCEhnVgf1b0pf2pE9x",
+          "jvIhT7CNJB2xhe1prdI97"
+        ],
+        "ui": {
+          "x": 51,
+          "y": 416,
+          "zIndex": 363,
+          "widthName": 113,
+          "widthComment": 60,
+          "color": "#3F51B5"
+        },
+        "meta": {
+          "updateAt": 1750765175119,
+          "createAt": 1750765104737
+        }
+      },
+      "aiSl3xVOB6NILvVS-vhBV": {
+        "id": "aiSl3xVOB6NILvVS-vhBV",
+        "name": "dm_monthly_frequent_evaluator",
+        "comment": "월간 투표 우수자",
+        "columnIds": [
+          "-RP_6Uue2xc8ne_DtT42X",
+          "_Z6PUsGcYUJVntLWZSgfJ",
+          "SGdckuV8Ez6qFAsSomIMV",
+          "2XoHM8WRg-g9G0NqYEYyY"
+        ],
+        "seqColumnIds": [
+          "-RP_6Uue2xc8ne_DtT42X",
+          "_Z6PUsGcYUJVntLWZSgfJ",
+          "SGdckuV8Ez6qFAsSomIMV",
+          "2XoHM8WRg-g9G0NqYEYyY"
+        ],
+        "ui": {
+          "x": 52,
+          "y": 657,
+          "zIndex": 435,
+          "widthName": 172,
+          "widthComment": 93,
+          "color": "#3F51B5"
+        },
+        "meta": {
+          "updateAt": 1750765221918,
+          "createAt": 1750765197890
         }
       }
     },
@@ -1669,6 +1766,326 @@
         "meta": {
           "updateAt": 1750097725578,
           "createAt": 1750097696587
+        }
+      },
+      "pfW0CRc8rAp0-hSr4apnH": {
+        "id": "pfW0CRc8rAp0-hSr4apnH",
+        "tableId": "aWWLtTHq8_sIUXawd8XTA",
+        "name": "count",
+        "comment": "평가 횟수",
+        "dataType": "INTEGER",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765026145,
+          "createAt": 1750765015075
+        }
+      },
+      "By9HRYZW5vLYg3lUjNI3V": {
+        "id": "By9HRYZW5vLYg3lUjNI3V",
+        "tableId": "Q0xopLdzEA-3f-1nF6xeG",
+        "name": "evaluator",
+        "comment": "평가 횟수",
+        "dataType": "BIGINT",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765094272,
+          "createAt": 1750765048517
+        }
+      },
+      "rj0G2MNfu-V9dnwL59G-l": {
+        "id": "rj0G2MNfu-V9dnwL59G-l",
+        "tableId": "Q0xopLdzEA-3f-1nF6xeG",
+        "name": "cumulative",
+        "comment": "누적 평가 횟수",
+        "dataType": "BIGINT",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 81,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765095164,
+          "createAt": 1750765048903
+        }
+      },
+      "fRw-0ZAbWGpXW6u9dsgs1": {
+        "id": "fRw-0ZAbWGpXW6u9dsgs1",
+        "tableId": "Q0xopLdzEA-3f-1nF6xeG",
+        "name": "difference",
+        "comment": "지난달과 차이값",
+        "dataType": "BIGINT",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 89,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765095636,
+          "createAt": 1750765049042
+        }
+      },
+      "GgUw7uzosZgeOLeFAEQ_U": {
+        "id": "GgUw7uzosZgeOLeFAEQ_U",
+        "tableId": "Q0xopLdzEA-3f-1nF6xeG",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765049190,
+          "createAt": 1750765049190
+        }
+      },
+      "NZiQOpaBYQyYlsniC4chh": {
+        "id": "NZiQOpaBYQyYlsniC4chh",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "min",
+        "comment": "최솟값",
+        "dataType": "INTEGER",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765179840,
+          "createAt": 1750765129062
+        }
+      },
+      "gUfB9WFnqCsSSgh4v5y1Q": {
+        "id": "gUfB9WFnqCsSSgh4v5y1Q",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "max",
+        "comment": "최댓값",
+        "dataType": "INTEGER",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765182412,
+          "createAt": 1750765129377
+        }
+      },
+      "V8W8Q4iP9QzR3KvOJNpx8": {
+        "id": "V8W8Q4iP9QzR3KvOJNpx8",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "avg",
+        "comment": "평균값",
+        "dataType": "DECIMAL(3,2)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 74,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765186359,
+          "createAt": 1750765129675
+        }
+      },
+      "eH5cBr8UaC30iBHRw2J80": {
+        "id": "eH5cBr8UaC30iBHRw2J80",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "q1",
+        "comment": "Q1",
+        "dataType": "INTEGER",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765189405,
+          "createAt": 1750765129814
+        }
+      },
+      "JueMfHPJF0D246XgCRsTo": {
+        "id": "JueMfHPJF0D246XgCRsTo",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "q3",
+        "comment": "Q3",
+        "dataType": "INTEGER",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765191843,
+          "createAt": 1750765129963
+        }
+      },
+      "SIZsCEhnVgf1b0pf2pE9x": {
+        "id": "SIZsCEhnVgf1b0pf2pE9x",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "variance",
+        "comment": "분산",
+        "dataType": "DECIMAL(3,2)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 74,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765194059,
+          "createAt": 1750765130103
+        }
+      },
+      "jvIhT7CNJB2xhe1prdI97": {
+        "id": "jvIhT7CNJB2xhe1prdI97",
+        "tableId": "xaLUTy9c4mxwakZJ9Rlnz",
+        "name": "stdev",
+        "comment": "표준편차",
+        "dataType": "DECIMAL(3,2)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 74,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765196823,
+          "createAt": 1750765150936
+        }
+      },
+      "-RP_6Uue2xc8ne_DtT42X": {
+        "id": "-RP_6Uue2xc8ne_DtT42X",
+        "tableId": "aiSl3xVOB6NILvVS-vhBV",
+        "name": "rank",
+        "comment": "순위",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765258197,
+          "createAt": 1750765221533
+        }
+      },
+      "_Z6PUsGcYUJVntLWZSgfJ": {
+        "id": "_Z6PUsGcYUJVntLWZSgfJ",
+        "tableId": "aiSl3xVOB6NILvVS-vhBV",
+        "name": "name",
+        "comment": "평가자 이름",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765261191,
+          "createAt": 1750765221664
+        }
+      },
+      "SGdckuV8Ez6qFAsSomIMV": {
+        "id": "SGdckuV8Ez6qFAsSomIMV",
+        "tableId": "aiSl3xVOB6NILvVS-vhBV",
+        "name": "evaluates",
+        "comment": "평가 횟수",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765252929,
+          "createAt": 1750765221795
+        }
+      },
+      "2XoHM8WRg-g9G0NqYEYyY": {
+        "id": "2XoHM8WRg-g9G0NqYEYyY",
+        "tableId": "aiSl3xVOB6NILvVS-vhBV",
+        "name": "last_evaluate",
+        "comment": "최근 평가",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1750765255782,
+          "createAt": 1750765221918
         }
       }
     },

--- a/erd/ssabab_dm.erd.json
+++ b/erd/ssabab_dm.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 2000,
     "height": 2000,
-    "scrollTop": 0,
-    "scrollLeft": -96.2672,
-    "zoomLevel": 1,
+    "scrollTop": -337.4958,
+    "scrollLeft": -286.0897,
+    "zoomLevel": 0.67,
     "show": 431,
     "database": 16,
     "databaseName": "",
@@ -46,36 +46,6 @@
   },
   "collections": {
     "tableEntities": {
-      "Z9PCVNnj-bCYfBjZMCs3j": {
-        "id": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "dm_monthly_vote_count",
-        "comment": "기수, 반, 성별, 나이 분포",
-        "columnIds": [
-          "8E2adrVgSXlOsOvRTIwJb",
-          "uCz-ic6AoDQ3_N3Eg0-JA",
-          "Sx1F1ZaUqY1A9PLN9-iBW",
-          "oJ6kO-JFaaaNCZLVjFd52"
-        ],
-        "seqColumnIds": [
-          "8E2adrVgSXlOsOvRTIwJb",
-          "uCz-ic6AoDQ3_N3Eg0-JA",
-          "Sx1F1ZaUqY1A9PLN9-iBW",
-          "oJ6kO-JFaaaNCZLVjFd52",
-          "9zNKfaPgpk-b6UNkB3y7j"
-        ],
-        "ui": {
-          "x": 419.6923,
-          "y": 853.7561,
-          "zIndex": 2,
-          "widthName": 131,
-          "widthComment": 131,
-          "color": "#3F51B5"
-        },
-        "meta": {
-          "updateAt": 1750083783119,
-          "createAt": 1746683497255
-        }
-      },
       "aWWLtTHq8_sIUXawd8XTA": {
         "id": "aWWLtTHq8_sIUXawd8XTA",
         "name": "dm_monthly_food_ranking",
@@ -208,7 +178,6 @@
         "name": "dm_user_group_comparison",
         "comment": "사용자와 전체/성별/연령대 비교",
         "columnIds": [
-          "qXQGHzlPHqZphefCatf1I",
           "ywSsC0aF40XulxrqdQhd0",
           "tWSWGXWGpry0WVmVcb-IT",
           "_noBDbOY9Am3ZT29zpuPC",
@@ -216,7 +185,6 @@
           "y9QbHXqbiCRyFlzpVK3QC"
         ],
         "seqColumnIds": [
-          "qXQGHzlPHqZphefCatf1I",
           "hIH_pTTAzpP3BlzUdKLaj",
           "6LZMdC65_N7mX_hOmOTXX",
           "PuLYWMNRPyMZyGItshqxx",
@@ -247,13 +215,11 @@
         "comment": "사용자 기본 통계 정보",
         "columnIds": [
           "3ebLNvh1Qo66PyrqMjHHB",
-          "gifsUr53RYLADMJ_OcGCq",
           "vqkPpO3eUmpZhm5C3Q0ki",
           "Z8Yv0g0beVDFU5naZnfL9"
         ],
         "seqColumnIds": [
           "3ebLNvh1Qo66PyrqMjHHB",
-          "gifsUr53RYLADMJ_OcGCq",
           "vqkPpO3eUmpZhm5C3Q0ki",
           "Z8Yv0g0beVDFU5naZnfL9"
         ],
@@ -275,14 +241,10 @@
         "name": "dm_user_insight",
         "comment": "사용자 인사이트 요약",
         "columnIds": [
-          "n8a2IrrQblX9kobJdeHn6",
-          "CHFBcE7GE552QTWpX8PCr"
+          "n8a2IrrQblX9kobJdeHn6"
         ],
         "seqColumnIds": [
-          "n8a2IrrQblX9kobJdeHn6",
-          "CHFBcE7GE552QTWpX8PCr",
-          "CyV9XXERy9tqiBx5VjtTj",
-          "zFLeOnCYihn6RU7lCIhOo"
+          "n8a2IrrQblX9kobJdeHn6"
         ],
         "ui": {
           "x": 1005.0655,
@@ -302,16 +264,12 @@
         "name": "dm_user_category_stats",
         "comment": "사용자 카테고리 통계",
         "columnIds": [
-          "K74oNPx2twolf0-lvDzdz",
           "W4xZxyDBqdqGM_aTfkrkQ",
-          "WmLmramvQTUWq5JtKKRVO",
-          "e47z5OWetLF2WjGlaumiw"
+          "WmLmramvQTUWq5JtKKRVO"
         ],
         "seqColumnIds": [
-          "K74oNPx2twolf0-lvDzdz",
           "W4xZxyDBqdqGM_aTfkrkQ",
-          "WmLmramvQTUWq5JtKKRVO",
-          "e47z5OWetLF2WjGlaumiw"
+          "WmLmramvQTUWq5JtKKRVO"
         ],
         "ui": {
           "x": 1002.9906,
@@ -331,16 +289,12 @@
         "name": "dm_user_tag_stats",
         "comment": "사용자 태그 통계",
         "columnIds": [
-          "i21RKiFKsBJ-RJoXvuJzZ",
           "1Xpy8mi6XMFUb2_DkVLl8",
-          "eMYn08HHMkWbIjRFXAGjy",
-          "3iqziJMk7an8kqhF_CqE6"
+          "eMYn08HHMkWbIjRFXAGjy"
         ],
         "seqColumnIds": [
-          "i21RKiFKsBJ-RJoXvuJzZ",
           "1Xpy8mi6XMFUb2_DkVLl8",
-          "eMYn08HHMkWbIjRFXAGjy",
-          "3iqziJMk7an8kqhF_CqE6"
+          "eMYn08HHMkWbIjRFXAGjy"
         ],
         "ui": {
           "x": 1409.3147,
@@ -354,252 +308,9 @@
           "updateAt": 1750737507008,
           "createAt": 1750096511236
         }
-      },
-      "Q2xhhGhLK-c7vEoLJzYf-": {
-        "id": "Q2xhhGhLK-c7vEoLJzYf-",
-        "name": "dm_user_score_comparison",
-        "comment": "사용자와 전체/성별/연령대 평점 비교",
-        "columnIds": [
-          "KAGFrCg31mWJclixRJt_o",
-          "vfbUVaUB76HUvC8OfpCwq",
-          "Ku61YQSS_hnhePulWy_9-",
-          "MvilXl0WeOGyITOJutm6Z"
-        ],
-        "seqColumnIds": [
-          "KAGFrCg31mWJclixRJt_o",
-          "vfbUVaUB76HUvC8OfpCwq",
-          "Ku61YQSS_hnhePulWy_9-",
-          "MvilXl0WeOGyITOJutm6Z"
-        ],
-        "ui": {
-          "x": 1507.9545,
-          "y": 824.6211,
-          "zIndex": 309,
-          "widthName": 147,
-          "widthComment": 201,
-          "color": "#795548"
-        },
-        "meta": {
-          "updateAt": 1750097690522,
-          "createAt": 1750097613319
-        }
       }
     },
     "tableColumnEntities": {
-      "BDOxHMr0ZaKb_728-u9Ci": {
-        "id": "BDOxHMr0ZaKb_728-u9Ci",
-        "tableId": "yrUN3y2qJ6x02CtUR9C5w",
-        "name": "date",
-        "comment": "",
-        "dataType": "DATE",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1746683497254,
-          "createAt": 1746683497254
-        }
-      },
-      "FzANZHH99zsB5BvMA_qAV": {
-        "id": "FzANZHH99zsB5BvMA_qAV",
-        "name": "dm_monthly_count",
-        "comment": "월간 평가수",
-        "columnIds": [
-          "BAfMqYHDeE99cySp6PD1a",
-          "IVrDtJqSboJ7tU1pLAWV3",
-          "9MkCjFN5sviodo0Z7wUD1"
-        ],
-        "seqColumnIds": [
-          "BAfMqYHDeE99cySp6PD1a",
-          "-NUgSPL12fCDf0rZGzdIx",
-          "IVrDtJqSboJ7tU1pLAWV3",
-          "9MkCjFN5sviodo0Z7wUD1"
-        ],
-        "ui": {
-          "x": 51.3399,
-          "y": 258.1246,
-          "zIndex": 184,
-          "widthName": 103,
-          "widthComment": 65,
-          "color": "#3F51B5"
-        },
-        "meta": {
-          "updateAt": 1750084202081,
-          "createAt": 1750061902507
-        }
-      },
-      "RJXcnH9sCO3qHJv0rpm-s": {
-        "id": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "dm_monthly_statistic",
-        "comment": "월간 통계",
-        "columnIds": [
-          "_laP4Bs7QzK9ZtzdPKavU",
-          "ZpU1s2W1yb_V0lf3fh14e",
-          "gT28TgIOwN2V74gwaDGIj",
-          "3PV7hoGXUdVUvybU9swig",
-          "MQ-rL-B3eJfZZdpk1X31z",
-          "Du5kOJ6n3Mx3424ZkxQaZ",
-          "FN5dJ876Z_1IAx57ily4h"
-        ],
-        "seqColumnIds": [
-          "_laP4Bs7QzK9ZtzdPKavU",
-          "ZpU1s2W1yb_V0lf3fh14e",
-          "gT28TgIOwN2V74gwaDGIj",
-          "3PV7hoGXUdVUvybU9swig",
-          "MQ-rL-B3eJfZZdpk1X31z",
-          "Du5kOJ6n3Mx3424ZkxQaZ",
-          "FN5dJ876Z_1IAx57ily4h"
-        ],
-        "ui": {
-          "x": 53.5258,
-          "y": 396.0858,
-          "zIndex": 239,
-          "widthName": 113,
-          "widthComment": 60,
-          "color": "#3F51B5"
-        },
-        "meta": {
-          "updateAt": 1750327679067,
-          "createAt": 1750083663952
-        }
-      },
-      "Nv9NP8P2Q0RTBeQk-71Fc": {
-        "id": "Nv9NP8P2Q0RTBeQk-71Fc",
-        "name": "dm_monthly_frequent_evaluator",
-        "comment": "월간 투표 우수자",
-        "columnIds": [
-          "QJohMDDp5mwz3X6qypdYj",
-          "EahOgkzxsKDaP-6XSyWak",
-          "qFX76b2mfdOxcx_kxsFXx",
-          "chumPYXVVlN_WPw5SaT-3"
-        ],
-        "seqColumnIds": [
-          "QJohMDDp5mwz3X6qypdYj",
-          "EahOgkzxsKDaP-6XSyWak",
-          "qFX76b2mfdOxcx_kxsFXx",
-          "chumPYXVVlN_WPw5SaT-3"
-        ],
-        "ui": {
-          "x": 53.5329,
-          "y": 628.1995,
-          "zIndex": 290,
-          "widthName": 172,
-          "widthComment": 93,
-          "color": "#3F51B5"
-        },
-        "meta": {
-          "updateAt": 1750085025403,
-          "createAt": 1750083777412
-        }
-      }
-    },
-    "tableColumnEntities": {
-      "8E2adrVgSXlOsOvRTIwJb": {
-        "id": "8E2adrVgSXlOsOvRTIwJb",
-        "tableId": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "class_num",
-        "comment": "",
-        "dataType": "VARCHAR",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750061833347,
-          "createAt": 1746683497255
-        }
-      },
-      "uCz-ic6AoDQ3_N3Eg0-JA": {
-        "id": "uCz-ic6AoDQ3_N3Eg0-JA",
-        "tableId": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "generation",
-        "comment": "",
-        "dataType": "VARCHAR",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750061829374,
-          "createAt": 1746683497255
-        }
-      },
-      "Sx1F1ZaUqY1A9PLN9-iBW": {
-        "id": "Sx1F1ZaUqY1A9PLN9-iBW",
-        "tableId": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "gender",
-        "comment": "",
-        "dataType": "VARCHAR",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750061826083,
-          "createAt": 1746683497255
-        }
-      },
-      "9zNKfaPgpk-b6UNkB3y7j": {
-        "id": "9zNKfaPgpk-b6UNkB3y7j",
-        "tableId": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "avg_score",
-        "comment": "",
-        "dataType": "NUMERIC(3,2)",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 77,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1746683497255,
-          "createAt": 1746683497255
-        }
-      },
-      "oJ6kO-JFaaaNCZLVjFd52": {
-        "id": "oJ6kO-JFaaaNCZLVjFd52",
-        "tableId": "Z9PCVNnj-bCYfBjZMCs3j",
-        "name": "age",
-        "comment": "",
-        "dataType": "INTEGER",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750061837443,
-          "createAt": 1746683497255
-        }
-      },
       "k2_-6gZZwVSbhqeqgklhi": {
         "id": "k2_-6gZZwVSbhqeqgklhi",
         "tableId": "aWWLtTHq8_sIUXawd8XTA",
@@ -1580,26 +1291,6 @@
           "createAt": 1750096280133
         }
       },
-      "BAfMqYHDeE99cySp6PD1a": {
-        "id": "BAfMqYHDeE99cySp6PD1a",
-        "tableId": "FzANZHH99zsB5BvMA_qAV",
-        "name": "evaluator",
-        "comment": "평가 횟수",
-        "dataType": "BIGINT",
-        "default": "0",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750328515567,
-          "createAt": 1750061923039
-        }
-      },
       "vqkPpO3eUmpZhm5C3Q0ki": {
         "id": "vqkPpO3eUmpZhm5C3Q0ki",
         "tableId": "SrvkylR2_N90GUNAp0GYs",
@@ -1740,26 +1431,6 @@
           "createAt": 1750096331027
         }
       },
-      "_laP4Bs7QzK9ZtzdPKavU": {
-        "id": "_laP4Bs7QzK9ZtzdPKavU",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "min",
-        "comment": "최솟값",
-        "dataType": "INTEGER",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750096510371,
-          "createAt": 1750096468876
-        }
-      },
       "W4xZxyDBqdqGM_aTfkrkQ": {
         "id": "W4xZxyDBqdqGM_aTfkrkQ",
         "tableId": "ln56DI9getvYTEpATq3ad",
@@ -1800,46 +1471,6 @@
           "createAt": 1750083712770
         }
       },
-      "ZpU1s2W1yb_V0lf3fh14e": {
-        "id": "ZpU1s2W1yb_V0lf3fh14e",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "max",
-        "comment": "최댓값",
-        "dataType": "INTEGER",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750327564975,
-          "createAt": 1750083716457
-        }
-      },
-      "gT28TgIOwN2V74gwaDGIj": {
-        "id": "gT28TgIOwN2V74gwaDGIj",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "avg",
-        "comment": "평균값",
-        "dataType": "DECIMAL(3,2)",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750096573284,
-          "createAt": 1750096538028
-        }
-      },
       "1Xpy8mi6XMFUb2_DkVLl8": {
         "id": "1Xpy8mi6XMFUb2_DkVLl8",
         "tableId": "gvNw89GeHxzNzb2kOG0Tf",
@@ -1872,52 +1503,12 @@
           "keys": 0,
           "widthName": 60,
           "widthComment": 60,
-          "widthDataType": 74,
+          "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
           "updateAt": 1750327773078,
           "createAt": 1750083720527
-        }
-      },
-      "3PV7hoGXUdVUvybU9swig": {
-        "id": "3PV7hoGXUdVUvybU9swig",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "q1",
-        "comment": "Q1",
-        "dataType": "INTEGER",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750327927450,
-          "createAt": 1750083724184
-        }
-      },
-      "MQ-rL-B3eJfZZdpk1X31z": {
-        "id": "MQ-rL-B3eJfZZdpk1X31z",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "q3",
-        "comment": "Q3",
-        "dataType": "INTEGER",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750096722125,
-          "createAt": 1750096641141
         }
       },
       "ywSsC0aF40XulxrqdQhd0": {
@@ -2000,46 +1591,6 @@
           "createAt": 1750083742420
         }
       },
-      "Du5kOJ6n3Mx3424ZkxQaZ": {
-        "id": "Du5kOJ6n3Mx3424ZkxQaZ",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "variance",
-        "comment": "분산",
-        "dataType": "DECIMAL(3,2)",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 74,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750327780377,
-          "createAt": 1750083751591
-        }
-      },
-      "FN5dJ876Z_1IAx57ily4h": {
-        "id": "FN5dJ876Z_1IAx57ily4h",
-        "tableId": "RJXcnH9sCO3qHJv0rpm-s",
-        "name": "stdev",
-        "comment": "표준편차",
-        "dataType": "DECIMAL(3,2)",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 74,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750327782305,
-          "createAt": 1750083756881
-        }
-      },
       "ZEkl2NrhOd-mXVuNiyizq": {
         "id": "ZEkl2NrhOd-mXVuNiyizq",
         "tableId": "TpwKX2hnuRee-6D7CByLG",
@@ -2078,106 +1629,6 @@
         "meta": {
           "updateAt": 1750097011628,
           "createAt": 1750097000044
-        }
-      },
-      "chumPYXVVlN_WPw5SaT-3": {
-        "id": "chumPYXVVlN_WPw5SaT-3",
-        "tableId": "Nv9NP8P2Q0RTBeQk-71Fc",
-        "name": "last_evaluate",
-        "comment": "최근 평가",
-        "dataType": "DATETIME",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 66,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750328096427,
-          "createAt": 1750083845497
-        }
-      },
-      "IVrDtJqSboJ7tU1pLAWV3": {
-        "id": "IVrDtJqSboJ7tU1pLAWV3",
-        "tableId": "FzANZHH99zsB5BvMA_qAV",
-        "name": "cumulative",
-        "comment": "누적 평가 횟수",
-        "dataType": "BIGINT",
-        "default": "0",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750328509660,
-          "createAt": 1750084021413
-        }
-      },
-      "9MkCjFN5sviodo0Z7wUD1": {
-        "id": "9MkCjFN5sviodo0Z7wUD1",
-        "tableId": "FzANZHH99zsB5BvMA_qAV",
-        "name": "difference",
-        "comment": "지난달과 차이값",
-        "dataType": "BIGINT",
-        "default": "0",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 62,
-          "widthComment": 116,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750328511859,
-          "createAt": 1750084059109
-        }
-      },
-      "Ku61YQSS_hnhePulWy_9-": {
-        "id": "Ku61YQSS_hnhePulWy_9-",
-        "tableId": "Q2xhhGhLK-c7vEoLJzYf-",
-        "name": "user_avg_score",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 81,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750097680991,
-          "createAt": 1750097647483
-        }
-      },
-      "MvilXl0WeOGyITOJutm6Z": {
-        "id": "MvilXl0WeOGyITOJutm6Z",
-        "tableId": "Q2xhhGhLK-c7vEoLJzYf-",
-        "name": "group_avg_score",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 91,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1750097686146,
-          "createAt": 1750097647778
         }
       },
       "tWSWGXWGpry0WVmVcb-IT": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,7 @@ requests==2.31.0
 # LLM
 transformers==4.52.4
 accelerate==1.7.0
+
+# MLOps - FM
+scikit-learn
+mlflow

--- a/spark/spark-jobs/data-mart/create_dm_mlops_data.py
+++ b/spark/spark-jobs/data-mart/create_dm_mlops_data.py
@@ -1,0 +1,114 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, avg, count, collect_list, to_json, struct, when, lit, explode, first
+from utils.db import get_mysql_jdbc_url, get_mysql_jdbc_properties
+import sys
+from datetime import datetime
+
+spark = SparkSession.builder.appName("CreateMLMenuComparison").getOrCreate()
+
+# 파라미터로 날짜 받기
+if len(sys.argv) > 1:
+    target_date = sys.argv[1]
+else:
+    target_date = datetime.now().strftime("%Y-%m-%d")
+
+# DB 연결
+jdbc_url = get_mysql_jdbc_url()
+jdbc_props = get_mysql_jdbc_properties()
+
+# 테이블 로드
+account = spark.read.jdbc(jdbc_url, "account", properties=jdbc_props)
+menu = spark.read.jdbc(jdbc_url, "menu", properties=jdbc_props).filter(col("date") == target_date)
+menu_review = spark.read.jdbc(jdbc_url, "menu_review", properties=jdbc_props).filter(col("timestamp").cast("date") == target_date)
+menu_food = spark.read.jdbc(jdbc_url, "menu_food", properties=jdbc_props)
+food = spark.read.jdbc(jdbc_url, "food", properties=jdbc_props)
+food_review = spark.read.jdbc(jdbc_url, "food_review", properties=jdbc_props)
+
+# 1. 날짜별 menu_id 쌍 생성 (menu 테이블 기준)
+menu_pairs = (
+    menu.groupBy("date")
+    .agg(
+        first("menu_id", ignorenulls=True).alias("menu_id_a"),
+        first("menu_id", ignorenulls=True).alias("menu_id_b")  # 나중에 정렬 바꿔서 두 개 추출
+    )
+)
+
+# 2. 사용자 리뷰 (menu_review) → chosen_menu_id = 해당 날짜에 유저가 리뷰 남긴 메뉴
+user_chosen = (
+    menu_review
+    .withColumnRenamed("menu_id", "chosen_menu_id")
+    .select("user_id", "chosen_menu_id", "menu_score", col("timestamp").cast("date").alias("date"))
+)
+
+# 3. 사용자 정보
+user_features = (
+    account.select(
+        col("user_id"),
+        col("gender"),
+        col("age"),
+        col("ssafy_region").alias("region"),
+        col("class_num")
+    )
+)
+
+# 4. menu-food 관계
+menu_food_map = menu_food.join(food, "food_id")
+
+# 5. food_review 집계 (음식 특성)
+food_review_agg = food_review.groupBy("food_id").agg(
+    avg("food_score").alias("avg_food_score"),
+    count("id").alias("review_count")
+)
+
+# 6. food 특성 벡터화 (tag, category, main_sub)
+# → 여기선 단순 JSON 집계로 처리 (실제 운영에선 one-hot or word2vec 등 적용 가능)
+food_feature = (
+    food
+    .join(food_review_agg, "food_id", "left")
+    .select(
+        "food_id",
+        "category", "tag", "main_sub",
+        "avg_food_score", "review_count"
+    )
+)
+
+# 7. 메뉴별 food 특성 집계
+menu_feature = (
+    menu_food
+    .join(food_feature, "food_id")
+    .groupBy("menu_id")
+    .agg(
+        collect_list("food_id").alias("food_ids"),
+        avg("avg_food_score").alias("avg_food_score"),
+        count("review_count").alias("review_count")
+        # tag/category/main_sub도 집계 가능
+    )
+)
+
+# 8. 조인하여 최종 테이블 구성
+ml = (
+    user_chosen
+    .join(menu_pairs, "date")
+    .join(user_features, "user_id")
+    .join(menu_feature.alias("a"), col("menu_id_a") == col("a.menu_id"))
+    .join(menu_feature.alias("b"), col("menu_id_b") == col("b.menu_id"))
+    .withColumn("label", when(col("chosen_menu_id") == col("menu_id_a"), lit(0)).otherwise(lit(1)))
+    .select(
+        "user_id", "date", "menu_id_a", "menu_id_b", "chosen_menu_id", "label",
+        "gender", "age", "region", "class_num",
+        col("a.food_ids").alias("food_ids_a"),
+        col("a.avg_food_score").alias("avg_food_score_a"),
+        col("a.review_count").alias("review_count_a"),
+        col("b.food_ids").alias("food_ids_b"),
+        col("b.avg_food_score").alias("avg_food_score_b"),
+        col("b.review_count").alias("review_count_b"),
+    )
+)
+
+# 저장
+ml.write.jdbc(
+    url=jdbc_url,
+    table="ssabab_dm.ml_menu_comparison",
+    mode="append",
+    properties=jdbc_props
+)

--- a/spark/spark-jobs/data-mart/create_dm_monthly_count.py
+++ b/spark/spark-jobs/data-mart/create_dm_monthly_count.py
@@ -92,7 +92,7 @@ def main():
     # 결과 저장
     result_df.write.jdbc(
         url=mysql_url,
-        table="ssabab_dm.monthly_count",
+        table="ssabab_dm.dm_monthly_count",
         mode="overwrite",
         properties=mysql_props
     )

--- a/spark/spark-jobs/data-mart/create_dm_monthly_food_ranking.py
+++ b/spark/spark-jobs/data-mart/create_dm_monthly_food_ranking.py
@@ -58,7 +58,7 @@ def main():
 
     result_df.write.jdbc(
         url=mysql_url,
-        table="ssabab_dm.monthly_food_ranking",
+        table="ssabab_dm.dm_monthly_food_ranking",
         mode="overwrite",
         properties=mysql_props
     )

--- a/spark/spark-jobs/data-mart/create_dm_monthly_frequent_evaluator.py
+++ b/spark/spark-jobs/data-mart/create_dm_monthly_frequent_evaluator.py
@@ -83,7 +83,7 @@ def main():
     # 결과 저장
     result_df.write.jdbc(
         url=mysql_url,
-        table="ssabab_dm.monthly_frequent_evaluator",
+        table="ssabab_dm.dm_monthly_frequent_evaluator",
         mode="overwrite",
         properties=mysql_props
     )

--- a/spark/spark-jobs/data-mart/create_dm_monthly_statistic.py
+++ b/spark/spark-jobs/data-mart/create_dm_monthly_statistic.py
@@ -44,7 +44,7 @@ def main():
     # 결과 저장
     stats_df.write.jdbc(
         url=mysql_url,
-        table="ssabab_dm.monthly_statistic",
+        table="ssabab_dm.dm_monthly_statistic",
         mode="overwrite",
         properties=mysql_props
     )


### PR DESCRIPTION
## 📄 작업 내용
### MLOps 파이프라인 구성
- `dm_menu_comparison` 데이터 마트 스키마 설계 및 생성
- Spark 기반 ETL 스크립트 (`create_ml_menu_comparison.py`) 작성
- 메뉴 A/B 쌍 + 사용자 + food 기반 feature 집계 로직 포함
- Airflow DAG(`etl_dm_menu_comparison`) 구성
  - SparkSubmitOperator로 Spark ETL 실행
  - PythonOperator로 `.libfm` 포맷 학습용 데이터 생성

### FM 모델 학습 및 평가 자동화
- `train_and_evaluate_fm_model` DAG 작성
  - `train_fm`: libFM 실행 + MLflow로 파라미터, 모델, 예측 결과 기록
  - `evaluate_fm`: RMSE / Precision / Recall 계산 및 MLflow에 메트릭 기록
- 학습 DAG은 ETL DAG 마지막에 TriggerDagRunOperator로 연결 예정

### MLflow 환경 구성
- MLflow Tracking 서버 Docker Compose로 구축
  - 메타 정보는 **MySQL**에 저장 (`mysql+pymysql`)
  - 아티팩트는 **Google Drive (rclone mount)** 를 통해 `/mlflow/artifacts` 경로에 저장 예정
- `.env` 파일 기반 환경 변수로 backend-store-uri 구성
- Run 이름 및 아티팩트 네이밍 규칙 정리
  - Run Name: `train_{ds}`
  - 모델 파일: `model/fm_model_{ds}.bin`
  - 입력 데이터: `data/train_{ds}.libfm`
  - 예측 결과: `pred/pred_{ds}.txt`

<br></br>

## 📎 Issue 번호
#6 
#7 
#9 