### PR TITLE
feat: Docker 내부에 NVIDIA 런타임 지원 추가 (작업 진행 중)

### DIFF
--- a/airflow/dags/mlops_xgb_train_dag.py
+++ b/airflow/dags/mlops_xgb_train_dag.py
@@ -42,7 +42,7 @@ with DAG(
     )
 
     generate_train_data = generate_xgb_train_csv()
-    train_model = train_xgb_model()
+    train_model = train_xgb_model(generate_train_data)
 
     validate_model = DummyOperator(task_id="validate_model")
 

--- a/airflow/dags/tasks/train_xgb_model.py
+++ b/airflow/dags/tasks/train_xgb_model.py
@@ -63,7 +63,7 @@ def check_menu_count():
         raise AirflowSkipException(f"Menu doesn't exist")
 
 
-@task
+@task(queue="gpu")
 def train_xgb_model(csv_path):
     context = get_current_context()
     execution_date = context["execution_date"].format("YYYY-MM-DD")

--- a/docker/Dockerfile.airflow-nvidia
+++ b/docker/Dockerfile.airflow-nvidia
@@ -1,0 +1,57 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+ARG AIRFLOW_VERSION=2.10.5
+ARG PYTHON_VERSION=3.10
+ARG CONSTRAINT_URL=https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt
+
+# 기본 시스템 패키지 설치
+RUN apt update && apt install -y \
+    python3-pip python3-dev openjdk-17-jdk \
+    curl wget unzip gcc g++ make \
+    libfreetype6-dev libpng-dev libjpeg-dev pkg-config
+
+# 환경 변수 설정
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV SPARK_VERSION=3.5.4
+ENV SPARK_HOME=/opt/spark
+ENV PATH="${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}"
+
+# Spark 설치
+RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz && \
+    tar -xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz -C /opt/ && \
+    mv /opt/spark-${SPARK_VERSION}-bin-hadoop3 $SPARK_HOME && \
+    rm spark-${SPARK_VERSION}-bin-hadoop3.tgz
+
+# MySQL JDBC 드라이버 설치
+RUN wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar \
+    -O /opt/spark/jars/mysql-connector-java.jar
+
+# pip 업그레이드 및 Python 패키지 전체 설치 (Airflow + ML + Spark 등)
+RUN pip install --upgrade pip && \
+    pip install \
+        "apache-airflow[celery,postgres,redis]==2.10.5" \
+        apache-airflow-providers-apache-spark \
+        apache-airflow-providers-apache-kafka \
+        apache-airflow-providers-postgres \
+        confluent-kafka \
+        kafka-python \
+        pyspark==3.5.4 \
+        pymysql \
+        psycopg2-binary \
+        python-dotenv==1.0.1 \
+        pandas \
+        numpy \
+        transformers==4.52.4 \
+        accelerate==1.7.0 \
+        konlpy \
+        scikit-learn \
+        mlflow \
+        xgboost==1.7.6 \
+        PyYAML \
+        joblib==1.4.2 \
+        --constraint "${CONSTRAINT_URL}" && \
+    pip install torch==2.5.1+cu121 torchvision --index-url https://download.pytorch.org/whl/cu121
+
+
+# 작업 디렉토리 설정
+WORKDIR /opt/airflow


### PR DESCRIPTION
## 📄 작업 내용

* GPU 지원용 Airflow Worker 구성
  * 기존 `Dockerfile.airflow`를 보존하고, GPU 지원을 위한 `Dockerfile.airflow-nvidia` 추가
  * `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04` 기반으로 CUDA 환경 설정
  * PyTorch 2.5.1 (CUDA 12.1) 및 Spark 3.5.4, PyYAML, Transformers 등 프로젝트에 필요한 패키지 직접 설치

* Docker Compose 수정
  * `airflow-worker`에 `runtime: nvidia` 설정 추가
  * CUDA 활용을 위한 GPU queue (`--queues gpu`) 지정
  * `nvidia-ctk runtime configure --runtime=docker` 명령어를 사용해 Docker 데몬의 NVIDIA 런타임 설정 완료

* 미완성 상태:
  * airflow-worker 실행 시 unknown or invalid runtime name: nvidia 에러 발생
  * → Docker 데몬에 NVIDIA 런타임 설정을 완료했음에도 불구하고 런타임 인식 실패
  * → 원인 분석 및 해결 작업 진행 중


---

## 📎 Issue 번호
#7 